### PR TITLE
Image collection support.

### DIFF
--- a/addons/vnen.tiled_importer/import_dialog.gd
+++ b/addons/vnen.tiled_importer/import_dialog.gd
@@ -79,6 +79,13 @@ func _ready():
 			"text": "",
 			"default": "tilesets/",
 		},
+		"separate_img_dir": {
+			"name": "Create seperate image directories",
+			"tooltip": "Create a directory per TileSet when using image collection sets.",
+			"type": TreeItem.CELL_MODE_CHECK,
+			"text": "On",
+			"default": false,
+		},
 		"image_flags": {
 			"name": "Image flags",
 			"tooltip": "Flags to apply to the imported TileSet image.",

--- a/addons/vnen.tiled_importer/tiled_importer_plugin.gd
+++ b/addons/vnen.tiled_importer/tiled_importer_plugin.gd
@@ -60,6 +60,7 @@ func import(path, metadata):
 		"embed": metadata.get_option("embed"),
 		"rel_path": metadata.get_option("rel_path"),
 		"image_flags": metadata.get_option("image_flags"),
+		"separate_img_dir": metadata.get_option("separate_img_dir"),
 		"target": path,
 	}
 


### PR DESCRIPTION
See issue #4
I am now saving the image files named like `TILESET-NAME_SOURCE-FILENAME_RELID.png` to prevent one tile image from overwriting others in case they come from different directories but are having the same filename.

The description might need some work.