### PR TITLE
Fixes triangular collision shape import

### DIFF
--- a/addons/vnen.tiled_importer/tiled_map.gd
+++ b/addons/vnen.tiled_importer/tiled_map.gd
@@ -343,8 +343,12 @@ func _shape_from_object(obj):
 			shape.set_polygon(vertices)
 			shape.set_closed("polygon" in obj)
 		else:
-			shape = ConcavePolygonShape2D.new()
-			shape.set_segments(vertices)
+			if vertices.size() == 3:
+				shape = ConvexPolygonShape2D.new()
+				shape.set_points(vertices)
+			else:
+				shape = ConcavePolygonShape2D.new()
+				shape.set_segments(vertices)
 
 	elif "ellipse" in obj:
 		if obj.type == "navigation" or obj.type == "occluder":


### PR DESCRIPTION
Like mentioned on IRC, collision polygons with 3 vertices lead to crashes as ConcavePolygonShape2D doesn't support this which leads to a shape with 0 vertices.

I just check if the polygon contains only 3 vertices and if thats the case use an ConvexShape2D.
