### PR TITLE
Fix of the convert function tmx -> json : the properties node was skipped

### DIFF
--- a/addons/vnen.tiled_importer/tiled_map.gd
+++ b/addons/vnen.tiled_importer/tiled_map.gd
@@ -960,7 +960,11 @@ func _parse_object(parser):
 					break
 
 			elif parser.get_node_type() == XMLParser.NODE_ELEMENT:
-				if parser.get_node_name() == "ellipse":
+				if parser.get_node_name() == "properties":
+					var prop_data = _parse_properties(parser)
+					data["properties"] = prop_data.properties
+					data["propertytypes"] = prop_data.propertytypes
+				elif parser.get_node_name() == "ellipse":
 					data.ellipse = true
 				elif parser.get_node_name() == "polygon" or parser.get_node_name() == "polyline":
 					var points = []


### PR DESCRIPTION
The custom properties are now added properly to the objects

Here a part of the tmx file I have:
```
<objectgroup name="objects">
  <object id="1" name="chest_1" x="96" y="128" width="16" height="16">
   <properties>
    <property name="Coins" type="int" value="10"/>
   </properties>
  </object>
```

Your function" _parse_object", waited a </object> so the properties where ignored before your condition 
`elif parser.get_node_name() == "properties":`
was read.
I also change to "elif" to "if" because "_parse_object" end now where the parse is on a "properties" node. (letting the elif will make the loop do another turn and skipping the node since it end with 
`err = parser.read()`
 ) 

If the text is too messy or ununderstandable, you can mail me here : fernandes.thomas.student@gmail.com