### PR TITLE
add an option to prevent images files to be copied

### DIFF
--- a/addons/vnen.tiled_importer/import_dialog.gd
+++ b/addons/vnen.tiled_importer/import_dialog.gd
@@ -81,6 +81,13 @@ func _ready():
 			"text": "",
 			"default": "tilesets/",
 		},
+		"keep_img": {
+			"name": "Don't save images",
+			"tooltip": "Don't save images. Keep them at their current locations.",
+			"type": TreeItem.CELL_MODE_CHECK,
+			"text": "On",
+			"default": false,
+		},
 		"separate_img_dir": {
 			"name": "Create separate image directories",
 			"tooltip": "Create a directory per TileSet when using image collection sets.",

--- a/addons/vnen.tiled_importer/tiled_importer_plugin.gd
+++ b/addons/vnen.tiled_importer/tiled_importer_plugin.gd
@@ -60,6 +60,7 @@ func import(path, metadata):
 		"embed": metadata.get_option("embed"),
 		"rel_path": metadata.get_option("rel_path"),
 		"image_flags": metadata.get_option("image_flags"),
+		"keep_img": metadata.get_option("keep_img"),
 		"separate_img_dir": metadata.get_option("separate_img_dir"),
 		"custom_properties": metadata.get_option("custom_properties"),
 		"post_script": str(metadata.get_option("post_script")).strip_edges(),

--- a/addons/vnen.tiled_importer/tiled_map.gd
+++ b/addons/vnen.tiled_importer/tiled_map.gd
@@ -745,10 +745,16 @@ func _load_image(source_img, target_folder, filename, width = false, height = fa
 
 	if not options.embed:
 		var target_image = target_folder.plus_file(filename)
-		var err = ResourceSaver.save(target_image, image)
-		if err != OK:
-			return "Couldn't save tileset image %s" % [target_image]
-		image.take_over_path(target_image)
+		if not options.keep_img:
+			var err = ResourceSaver.save(target_image, image)
+			if err != OK:
+				return "Couldn't save tileset image %s" % [target_image]
+			image.take_over_path(target_image)
+		# .flags files must be generated and so images must be (re)saved with the ResourceSaver
+		else:
+			var err = ResourceSaver.save(source_img, image)
+			if err != OK:
+				return "Couldn't save tileset image %s" % [source_img]
 
 	return image
 


### PR DESCRIPTION
When importing a tileset, image are copied to a given directory along with the generated .res file. This behaviour is not always wanted depending on the file hierarchy one would like to achieve.

I added an option to prevent the image files to be copied. This way, it's possible to keep the image files in one directory and the .res file in another.