### PR TITLE
FEATURE: tile objects inherit properties set in their tilesheet 

### DIFF
--- a/addons/vnen.tiled_importer/tiled_map.gd
+++ b/addons/vnen.tiled_importer/tiled_map.gd
@@ -554,8 +554,14 @@ func build():
 					object.add_child(sprite)
 					sprite.set_owner(scene)
 
-					if options.custom_properties and obj.has("properties") and obj.has("propertytypes"):
-						_set_meta(sprite, obj.properties, obj.propertytypes)
+					if options.custom_properties:
+						var tile = _tile_from_gid(tile_raw_id)
+
+						if tile != null and tile.has("properties") and tile.has("propertytypes"):
+							_set_meta(sprite, tile.properties, tile.propertytypes)
+
+						if obj.has("properties") and obj.has("propertytypes"):
+							_set_meta(sprite, obj.properties, obj.propertytypes)
 
 	if options.custom_properties and data.has("properties") and data.has("propertytypes"):
 		_set_meta(scene, data.properties, data.propertytypes)
@@ -577,6 +583,15 @@ func _tileset_from_gid(gid):
 		var map = tile_id_mapping[map_id]
 		if gid >= map.firstgid and gid < (map.firstgid + map.tilecount):
 			return map.tileset
+
+	return null
+
+# Get a tile based on the global tile id
+func _tile_from_gid(gid):
+	for tileset in data.tilesets:
+		if gid >= tileset.firstgid and gid < (tileset.firstgid + tileset.tilecount):
+			var rel_id = str(gid - tileset.firstgid)
+			return tileset.tiles[rel_id]
 
 	return null
 
@@ -949,6 +964,10 @@ func _parse_tile_data(parser):
 					obj_group.objects = []
 				var obj = _parse_object(parser)
 				obj_group.objects.push_back(obj)
+			elif parser.get_node_name() == "properties":
+				var prop_data = _parse_properties(parser)
+				data["properties"] = prop_data.properties
+				data["propertytypes"] = prop_data.propertytypes
 
 		err = parser.read()
 


### PR DESCRIPTION
Tile objects (as in, objects in an object layer that are of type "tile") now inherit the tile properties specified in their tilesheet.

This allows you to specify properties directly on the tile in its tilesheet, then see that data imported as metadata for the tile object.