### PR TITLE
BUGFIX: correct position of tile objects

### DIFF
--- a/addons/vnen.tiled_importer/tiled_map.gd
+++ b/addons/vnen.tiled_importer/tiled_map.gd
@@ -517,10 +517,11 @@ func build():
 					if tileset == null:
 						return "Invalid GID in object layer tile"
 
+					var is_tile_object = tileset.tile_get_region(tileid) == Rect2(0, 0, 0, 0)
 					var sprite = Sprite.new()
 					sprite.set_texture(tileset.tile_get_texture(tileid))
 
-					if not tileset.tile_get_region(tileid) == Rect2(0, 0, 0, 0):
+					if not is_tile_object:
 						sprite.set_region(true)
 						sprite.set_region_rect(tileset.tile_get_region(tileid))
 
@@ -539,6 +540,11 @@ func build():
 						pos.x = float(obj.x)
 					if obj.has("y"):
 						pos.y = float(obj.y)
+					if is_tile_object:
+						# Tile object positions are oriented bottom left.
+						# If we import their positioning data as is, their position ends up skewed incorrectly.
+						pos.x = pos.x + float(obj.width) / 2
+						pos.y = pos.y - float(obj.height) / 2
 					sprite.set_pos(pos)
 
 					var rot = 0

--- a/addons/vnen.tiled_importer/tiled_map.gd
+++ b/addons/vnen.tiled_importer/tiled_map.gd
@@ -554,8 +554,14 @@ func build():
 					object.add_child(sprite)
 					sprite.set_owner(scene)
 
-					if options.custom_properties and obj.has("properties") and obj.has("propertytypes"):
-						_set_meta(sprite, obj.properties, obj.propertytypes)
+					if options.custom_properties:
+						var tile = _tile_from_gid(tile_raw_id)
+
+						if tile != null and tile.has("properties") and tile.has("propertytypes"):
+							_set_meta(sprite, tile.properties, tile.propertytypes)
+
+						if obj.has("properties") and obj.has("propertytypes"):
+							_set_meta(sprite, obj.properties, obj.propertytypes)
 
 	if options.custom_properties and data.has("properties") and data.has("propertytypes"):
 		_set_meta(scene, data.properties, data.propertytypes)
@@ -577,6 +583,15 @@ func _tileset_from_gid(gid):
 		var map = tile_id_mapping[map_id]
 		if gid >= map.firstgid and gid < (map.firstgid + map.tilecount):
 			return map.tileset
+
+	return null
+
+# Get a tile based on the global tile id
+func _tile_from_gid(gid):
+	for tileset in data.tilesets:
+		if gid >= tileset.firstgid and gid < (tileset.firstgid + tileset.tilecount):
+			var rel_id = str(gid - tileset.firstgid)
+			return tileset.tiles[rel_id]
 
 	return null
 
@@ -949,6 +964,10 @@ func _parse_tile_data(parser):
 					obj_group.objects = []
 				var obj = _parse_object(parser)
 				obj_group.objects.push_back(obj)
+			elif parser.get_node_name() == "properties":
+				var prop_data = _parse_properties(parser)
+				data["properties"] = prop_data.properties
+				data["propertytypes"] = prop_data.propertytypes
 
 		err = parser.read()
 


### PR DESCRIPTION
On an object layer, a tile object's position is the bottom-leftmost part of the object. This is because, like all other objects, you can stretch and skew them. However, this doesn't mesh with sprite positioning, because sprites are positioned based on their center-point.

In order to deal with this, when setting the position of a tile object, we take the half width and half height in order to gain the true center and use that adjusted position as the sprite's position.