### PR TITLE
A small bug fix for reading custom properties.

### DIFF
--- a/addons/vnen.tiled_importer/tiled_map.gd
+++ b/addons/vnen.tiled_importer/tiled_map.gd
@@ -1022,7 +1022,12 @@ func _parse_object(parser):
 						})
 
 					data[parser.get_node_name()] = points
-
+				elif parser.get_node_name() == "properties":
+					var prop_data = _parse_properties(parser)
+					if typeof(prop_data) == TYPE_STRING:
+						return prop_data
+					data.properties = prop_data.properties
+					data.propertytypes = prop_data.propertytypes
 			err = parser.read()
 
 	for attr in ["width", "height", "x", "y", "rotation"]:


### PR DESCRIPTION
The following Tiled Custom Properties were not being read into Godot as meta correctly:

"collision_layer"
"collision_mask"

See the following screen shot for an example:

![example](https://user-images.githubusercontent.com/4543259/31866889-dfca787a-b753-11e7-9457-18cf47cfe48d.png)

This PR address searching for properties against objects.

Thanks.
