### PR TITLE
Rewrote large parts to make it fit Godot 3 Alpha 2's new import system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 !LICENSE
 !.gitignore
 !.gitattributes
+# Godot generated files		
+/.import/*		
+*.import

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,3 @@
 !LICENSE
 !.gitignore
 !.gitattributes
-# Godot generated files
-/.import/*
-*.import

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a plugin for [Godot Engine](https://godotengine.org) to import
 `TileMap`s and `TileSet`s from the [Tiled Map Editor](http://www.mapeditor.org).
 
-![](https://lut.im/uWPHymdSvs/l60C9UiVlrqK3bea.png)
+![](https://i.imgur.com/iRgqhlK.png)
 
 ## Installation
 
@@ -12,7 +12,7 @@ Simply download it from Godot Asset Library: https://godotengine.org/asset-libra
 Alternatively, download or clone this repository and copy the contents of the
 `addons` folder to your own project's `addons` folder.
 
-Then enable the plugin on the Project Settings.
+Then enable the plugin in the Project Settings' Plugins tab.
 
 ## Features
 
@@ -22,28 +22,26 @@ Then enable the plugin on the Project Settings.
 * Orthogonal and isometric maps.
 * Import visibility and opacity from layers.
 * Import collision/occluder/navigation shapes (based on Tiled object type).
-* Custom import options, such as whether to embed the resources into the scene.
-* Support for image layers
+* Custom import options, such as whether to embed the TileSet resource into the scene.
+* Support for image layers.
 * Support for object layers, which are imported as StaticBody2D or LightOccluder2D
   for shapes (depending on the `type` property) and as Sprite for tiles.
 * Custom properties for maps, layers, tilesets, and objects are imported as
   metadata.
-* Support for post-import script.
+* Custom properties for tiles are imported as a dictionary into the tileset's `tile_meta` metadata.
+* Support for post-import scripts.
 
 ## Usage
 
-1. In Godot, click on menu Import -> TileMap from Tiled Editor.
-2. Set the source Tiled file (either a `.json` or a `.tmx`).
-3. Set the target destination scene.
-4. Ajusted the desired options.
-5. Press ok.
+While the plugin is active, all .tmx files in the project directory will be automatically converted.
+To change a TileMap's import settings, select it in the FileSystem dock and check out the Import dock.
 
-If no error occurs, the generated scene will be stored where you set it. The
-TileSets will be on a relative folder or embedded, depending on the options.
+The TileSets will either be embedded into the resulting Scene or saved inside the specified directory.
+Source images are not moved, references are kept where they were.
 
 ## Caveats on Tiled maps
 
-* Godot TileSets only have on collision shape, so the last found will overwrite
+* Godot TileSet tiles only have one collision shape, so the last collision object found will overwrite
   the others.
 
 * The same goes for navigation/occluder polygons.
@@ -69,13 +67,15 @@ TileSets will be on a relative folder or embedded, depending on the options.
 
 ## Options
 
-### Post-import script
+### Post Scripts
 
-The selected script will have it's `post_import(scene)` method run. This
-enables you to change the generated scene automatically upon each reimport.
+All script files specified in the Array will have their `post_import(scene)`
+method runs. This enables you to change the generated scene automatically
+upon each reimport.
 
-The `post_import` method will receive the built scene and **must** return the
-changed scene.
+The `post_import` methods on each script file will receive the built scene
+as an argument and **must** return the changed scene. The scripts are ran
+in the order they are in the Array.
 
 ### Single TileSet
 
@@ -83,28 +83,34 @@ Save all Tiled tilesets a single Godot resource. If any of your layers uses
 more than one tileset image, this is required otherwise it won't be generated
 properly.
 
-### Embed resources
-
-Save all TileSets and images embedded in the target scene. Otherwise they will
-be saved individually in the selected relative folder.
-
-### Relative resource path
-
-The relative path from the target scene where to save the resources
-(images and tilesets).
-
-### Image flags
-
-The image flags to apply to all imported TileSet images.
-
-### Create separate image directories
-
-When the TileSet is a collection of images, this option tells tp create a new
-directory with the TileSet name to hold all of the images.
-
 ### Custom properties
 
 Whether or not to save the custom properties as metadata in the nodes and resources.
+
+### Bundle Tilesets
+
+Whether all tilesets used in Tiled should be bundled up into a single TileSet
+resource.
+This is needed when a layer in the TileMap uses 2 or more Tiled TileSets at the same
+time, as Godot only supports one TileSet per TileMap layer.
+The advantage to not using this setting is that every Tiled TileSet will only be
+imported once and all imported Scenes using the same Tiled TileSet will reference
+the same files, however this only works if TileSets are saved using the
+`Save Tilesets` option.
+
+### Save Tilesets
+
+Whether or not to save the TileSet resources generated during Tiled map import to the
+project directory instead of embedding them directly into the generated Scene file.
+Useful to save space if TileSets are shared between different Tiled maps, but only
+if they are not bundled using `Bundle Tilesets`.
+
+### Tileset Directory
+
+The absolute path to the directory that TileSets are saved to when `Save Tilesets`
+is enabled. The default is inside the `.import` directory that the Tiled maps are
+stored inside of, but this can be set to any directory outside of `.import` as well.
+
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a plugin for [Godot Engine](https://godotengine.org) to import
 `TileMap`s and `TileSet`s from the [Tiled Map Editor](http://www.mapeditor.org).
 
-![](https://i.imgur.com/iRgqhlK.png)
+![](https://i.imgur.com/BWcqnWi.png)
 
 ## Installation
 
@@ -69,13 +69,13 @@ Source images are not moved, references are kept where they were.
 
 ### Post Scripts
 
-All script files specified in the Array will have their `post_import(scene)`
-method runs. This enables you to change the generated scene automatically
-upon each reimport.
+The post-import GDScript file has its `post_import(scene)` method called.
+This enables you to change the generated scene automatically upon each reimport.
 
-The `post_import` methods on each script file will receive the built scene
-as an argument and **must** return the changed scene. The scripts are ran
-in the order they are in the Array.
+The `post_import` method receives the fully built scene as an argument and
+**must** return the changed scene.
+If you add any additional nodes to the scene, make sure to call `set_owner(scene)`
+on each of them so they are saved to the file system correctly.
 
 ### Single TileSet
 

--- a/addons/vnen.tiled_importer/plugin.cfg
+++ b/addons/vnen.tiled_importer/plugin.cfg
@@ -1,7 +1,7 @@
 [plugin]
 
 name="Tiled Map Importer"
-description="Importer for TileMaps and TileSets made on Tiled Map Editor"
-version="2"
+description="Importer for TileMaps and TileSets made in the Tiled Map Editor"
+version="2.0"
 author="George Marques"
 script="vnen.tiled_importer.gd"

--- a/addons/vnen.tiled_importer/plugin.cfg
+++ b/addons/vnen.tiled_importer/plugin.cfg
@@ -1,8 +1,7 @@
-config_version=3
 [plugin]
 
 name="Tiled Map Importer"
 description="Importer for TileMaps and TileSets made on Tiled Map Editor"
-version="2.0"
+version="2"
 author="George Marques"
 script="vnen.tiled_importer.gd"

--- a/addons/vnen.tiled_importer/tiled_importer_plugin.gd
+++ b/addons/vnen.tiled_importer/tiled_importer_plugin.gd
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2017 George Marques
+# Copyright (c) 2016 George Marques
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,90 +23,142 @@
 tool
 extends EditorImportPlugin
 
-const TiledMap = preload("res://addons/vnen.tiled_importer/tiled_map.gd")
+const TiledMap = preload("tiled_map.gd")
 const PLUGIN_NAME = "org.vnen.tiled_importer"
-
-var base_plugin = null
-
-func config(b):
-	base_plugin = b
-
-func get_preset_count():
-	return 0
-
-func get_preset_name(preset):
-	return "Default"
-
-func get_recognized_extensions():
-	return ['tmx', 'json']
-
-func get_save_extension():
-	return 'scn'
-
-func get_import_options(preset):
-	return [
-		{
-			"name": "textures/image_flags",
-			"default_value": 0,
-			"property_hint": PROPERTY_HINT_FLAGS,
-			"hint_string": "Mipmaps,Repeat,Filter,Anisotropic Filter,Convert to Linear,Mirrored Repeat"
-		}
-	]
-
-func get_visible_name():
-	return "Tiled Map as Scene"
-
-func get_resource_type():
-	return "PackedScene"
+var dialog = null
 
 func get_importer_name():
 	return PLUGIN_NAME
 
-func import(source_file, save_path, options, r_platform_variants, r_gen_files):
+func get_visible_name():
+	return "Tiled Editor TileMap"
 
-	print("import_options ", options)
+func get_recognized_extensions():
+	return ["tmx", "json"]
+
+func get_save_extension():
+	return "scn"
+
+func get_resource_type():
+	return "PackedScene"
+
+func get_option_visibility(option, options):
+	return true
+
+func get_preset_count():
+	return 1
+
+func get_preset_name(preset):
+	# There is only one preset, so we will only return that one ever
+	return "Default"
+
+func get_import_options(preset):
+	var options =  [
+		{
+			name = "post_scripts",
+			default_value = [],
+			#hint_string = "Post-Import Scripts",
+			#usage = "The importer will call post_import(scene) on each script file in the array. post_import() has to return the changed scene. (optional)",
+		},
+		{
+			name = "custom_properties",
+			default_value = true,
+			#hint_string = "Custom properties",
+			#usage = "Whether to import custom properties as meta data. Custom properties set as a dictionary in the tileset's meta data as 'tile_meta', indexed by the unique tile IDs.",
+		},
+		{
+			name = "bundle_tilesets",
+			default_value = false,
+			#hint_string = "Bundle TileSets into one",
+			#usage = "Mix all Tiled TileSets into a single Godot resource named after the map. Needed if your layers uses more than one tileset each. If false, each tileset will be saved individually using its Tiled name.",
+		},
+		{
+			name = "save_tilesets",
+			default_value = true,
+			#hint_string = "Save TileSets inside res://",
+			#usage = "Save the generated TileSet .res files directly inside the project folder instead of only embedding them inside the generated scene.",
+		},
+		{
+			name = "tileset_directory",
+			default_value = "res://.import/tilesets/",
+			#hint_string = "Tileset Directory",
+			#usage = "The absolute directory inside the project where all TileSet resources generated during TileMap import are saved. Only used if 'Save Tilesets' is true.",
+		},
+	]
+	
+	return options
+
+
+func import(src, path, import_options, r_platform_variants, r_gen_files):
 	var tiled_map = TiledMap.new()
-	var full_path = save_path + "." + get_save_extension()
-	var my_options = {
-		"single_tileset": true,
-		"embed": true,
-		"rel_path": "",
-		"image_flags": options["textures/image_flags"],
-		"separate_img_dir": false,
-		"custom_properties": true,
-		"post_script": "",
-		"target": full_path,
-	}
 
-	tiled_map.init(source_file, my_options)
+	var options = {}
+	for key in import_options:
+		options[key] = import_options[key]
+
+	options["target"] = path
+	print(options.tileset_directory)
+	if options.tileset_directory != "":
+		if options.tileset_directory.is_abs_path():
+			if options.tileset_directory[-1] != "/":
+				options.tileset_directory = options.tileset_directory + "/"
+		else:
+			print("Cannot find tileset directory, tilesets will not be saved.")
+			options.save_tilesets = false
+	print(options.tileset_directory)
+
+	tiled_map.init(src, options)
 
 	var tiled_data = tiled_map.get_data()
 
 	if typeof(tiled_data) == TYPE_STRING:
-		# If is string then it's an error message
-		print("errdata: ", tiled_data)
-		return ERR_WTF
+		# If it's a string then it's an error message
+		print(tiled_data)
+		return FAILED
+
+	if options.save_tilesets:
+		var dir = Directory.new()
+		dir.make_dir_recursive(options.tileset_directory)
 
 	var err = tiled_map.build()
-	if typeof(err) == TYPE_STRING and err != "OK":
-		# If is string then it's an error message
-		print("errbuild: ", err)
-		return ERR_WTF
+	if err != "OK":
+		return FAILED
 
 	var scene = tiled_map.get_scene()
+
+	for script_path in options["post_scripts"]:
+		if typeof(script_path) != TYPE_STRING:
+			continue
+		
+		script_path = script_path.strip_edges()
+		
+		var script = load(script_path)
+		if not script or not script is GDScript:
+			print("Error loading post import script %s" % [script_path])
+			return FAILED
+
+		script = script.new()
+		if not script.has_method("post_import"):
+			print('Script %s doesn\'t have "post_import" method' % script_path)
+			return FAILED
+
+		scene = script.post_import(scene)
+
+		if scene == null or not scene is Node2D:
+			print("Invalid scene returned from post import script %s" % script_path)
+			return FAILED
 
 	var packed_scene = PackedScene.new()
 	err = packed_scene.pack(scene)
 	if err != OK:
-		return err
+		print("Error packing scene")
+		return FAILED
 
-	err = ResourceSaver.save(full_path, packed_scene)
+	#packed_scene.set_import_metadata(metadata)
 
+	err = ResourceSaver.save("res://.import/prototype_tilemap.tmx-1fbab38439605f9c3c861b178197d792.scn", packed_scene)
 	if err != OK:
-		return err
+		print("Error saving scene")
+		return FAILED
 
-	base_plugin.reload_scene(source_file)
 	return OK
-
-func get_option_visibility(option, options):
-	return true

--- a/addons/vnen.tiled_importer/tiled_importer_plugin.gd
+++ b/addons/vnen.tiled_importer/tiled_importer_plugin.gd
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2016 George Marques
+# Copyright (c) 2017 George Marques
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,13 +25,17 @@ extends EditorImportPlugin
 
 const TiledMap = preload("tiled_map.gd")
 const PLUGIN_NAME = "org.vnen.tiled_importer"
-var dialog = null
+
+var base_plugin = null
+
+func config(base):
+	base_plugin = base
 
 func get_importer_name():
 	return PLUGIN_NAME
 
 func get_visible_name():
-	return "Tiled Editor TileMap"
+	return "Tiled Map to Scene"
 
 func get_recognized_extensions():
 	return ["tmx", "json"]
@@ -154,11 +158,12 @@ func import(src, path, import_options, r_platform_variants, r_gen_files):
 		print("Error packing scene")
 		return FAILED
 
-	#packed_scene.set_import_metadata(metadata)
-
 	err = ResourceSaver.save("res://.import/prototype_tilemap.tmx-1fbab38439605f9c3c861b178197d792.scn", packed_scene)
 	if err != OK:
 		print("Error saving scene")
 		return FAILED
+
+	if base_plugin != null:
+		base_plugin.reload_scene(src)
 
 	return OK

--- a/addons/vnen.tiled_importer/tiled_importer_plugin.gd
+++ b/addons/vnen.tiled_importer/tiled_importer_plugin.gd
@@ -25,7 +25,6 @@ extends EditorImportPlugin
 
 const TiledMap = preload("tiled_map.gd")
 const PLUGIN_NAME = "org.vnen.tiled_importer"
-
 var base_plugin = null
 
 func config(base):
@@ -53,7 +52,6 @@ func get_preset_count():
 	return 1
 
 func get_preset_name(preset):
-	# There is only one preset, so we will only return that one ever
 	return "Default"
 
 func get_import_options(preset):
@@ -61,47 +59,43 @@ func get_import_options(preset):
 		{
 			name = "post_scripts",
 			default_value = [],
-			#hint_string = "Post-Import Scripts",
-			#usage = "The importer will call post_import(scene) on each script file in the array. post_import() has to return the changed scene. (optional)",
+			#tooltip = "The importer will call post_import(scene) on each script file in the array. post_import() has to return the changed scene. (optional)",
 		},
 		{
 			name = "custom_properties",
 			default_value = true,
-			#hint_string = "Custom properties",
-			#usage = "Whether to import custom properties as meta data. Custom properties set as a dictionary in the tileset's meta data as 'tile_meta', indexed by the unique tile IDs.",
+			#tooltip = "Whether to import custom properties as meta data. Custom properties set as a dictionary in the tileset's meta data as 'tile_meta', indexed by the unique tile IDs.",
 		},
 		{
 			name = "bundle_tilesets",
 			default_value = false,
-			#hint_string = "Bundle TileSets into one",
-			#usage = "Mix all Tiled TileSets into a single Godot resource named after the map. Needed if your layers uses more than one tileset each. If false, each tileset will be saved individually using its Tiled name.",
+			#tooltip = "Mix all Tiled TileSets into a single Godot resource named after the map. Needed if your layers uses more than one tileset each. If false, each tileset will be saved individually using its Tiled name.",
 		},
 		{
 			name = "save_tilesets",
 			default_value = true,
-			#hint_string = "Save TileSets inside res://",
-			#usage = "Save the generated TileSet .res files directly inside the project folder instead of only embedding them inside the generated scene.",
+			#tooltip = "Save the generated TileSet .res files directly inside the project folder instead of only embedding them inside the generated scene.",
 		},
 		{
 			name = "tileset_directory",
 			default_value = "res://.import/tilesets/",
-			#hint_string = "Tileset Directory",
-			#usage = "The absolute directory inside the project where all TileSet resources generated during TileMap import are saved. Only used if 'Save Tilesets' is true.",
+			#tooltip = "The absolute directory inside the project where all TileSet resources generated during TileMap import are saved. Only used if 'Save Tilesets' is true.",
 		},
 	]
 	
 	return options
 
 
-func import(src, path, import_options, r_platform_variants, r_gen_files):
+func import(src, target_path, import_options, r_platform_variants, r_gen_files):
+	
+	target_path = target_path + "." + get_save_extension()
 	var tiled_map = TiledMap.new()
 
 	var options = {}
 	for key in import_options:
 		options[key] = import_options[key]
 
-	options["target"] = path
-	print(options.tileset_directory)
+	options["target"] = target_path
 	if options.tileset_directory != "":
 		if options.tileset_directory.is_abs_path():
 			if options.tileset_directory[-1] != "/":
@@ -109,14 +103,12 @@ func import(src, path, import_options, r_platform_variants, r_gen_files):
 		else:
 			print("Cannot find tileset directory, tilesets will not be saved.")
 			options.save_tilesets = false
-	print(options.tileset_directory)
 
 	tiled_map.init(src, options)
 
 	var tiled_data = tiled_map.get_data()
 
 	if typeof(tiled_data) == TYPE_STRING:
-		# If it's a string then it's an error message
 		print(tiled_data)
 		return FAILED
 
@@ -158,7 +150,8 @@ func import(src, path, import_options, r_platform_variants, r_gen_files):
 		print("Error packing scene")
 		return FAILED
 
-	err = ResourceSaver.save("res://.import/prototype_tilemap.tmx-1fbab38439605f9c3c861b178197d792.scn", packed_scene)
+	err = ResourceSaver.save(target_path, packed_scene)
+	print(target_path)
 	if err != OK:
 		print("Error saving scene")
 		return FAILED

--- a/addons/vnen.tiled_importer/tiled_importer_plugin.gd
+++ b/addons/vnen.tiled_importer/tiled_importer_plugin.gd
@@ -25,10 +25,6 @@ extends EditorImportPlugin
 
 const TiledMap = preload("tiled_map.gd")
 const PLUGIN_NAME = "org.vnen.tiled_importer"
-var base_plugin = null
-
-func config(base):
-	base_plugin = base
 
 func get_importer_name():
 	return PLUGIN_NAME
@@ -79,6 +75,7 @@ func get_import_options(preset):
 		{
 			name = "tileset_directory",
 			default_value = "res://.import/tilesets/",
+			property_hint = PROPERTY_HINT_DIR,
 			#tooltip = "The absolute directory inside the project where all TileSet resources generated during TileMap import are saved. Only used if 'Save Tilesets' is true.",
 		},
 	]
@@ -155,8 +152,5 @@ func import(src, target_path, import_options, r_platform_variants, r_gen_files):
 	if err != OK:
 		print("Error saving scene")
 		return FAILED
-
-	if base_plugin != null:
-		base_plugin.reload_scene(src)
 
 	return OK

--- a/addons/vnen.tiled_importer/tiled_importer_plugin.gd
+++ b/addons/vnen.tiled_importer/tiled_importer_plugin.gd
@@ -128,7 +128,7 @@ func import(src, target_path, import_options, r_platform_variants, r_gen_files):
 		if not script or not script is GDScript:
 			print("Error loading post import script %s" % [script_path])
 			return FAILED
-
+		
 		script = script.new()
 		if not script.has_method("post_import"):
 			print('Script %s doesn\'t have "post_import" method' % script_path)

--- a/addons/vnen.tiled_importer/tiled_importer_plugin.gd
+++ b/addons/vnen.tiled_importer/tiled_importer_plugin.gd
@@ -53,9 +53,10 @@ func get_preset_name(preset):
 func get_import_options(preset):
 	var options =  [
 		{
-			name = "post_scripts",
-			default_value = [],
-			#tooltip = "The importer will call post_import(scene) on each script file in the array. post_import() has to return the changed scene. (optional)",
+			name = "post_script",
+			default_value = "",
+			property_hint = PROPERTY_HINT_FILE,
+			#tooltip = "The importer will call post_import(scene) on the script at the given location. post_import() has to return the changed scene. (optional)",
 		},
 		{
 			name = "custom_properties",
@@ -119,10 +120,8 @@ func import(src, target_path, import_options, r_platform_variants, r_gen_files):
 
 	var scene = tiled_map.get_scene()
 
-	for script_path in options["post_scripts"]:
-		if typeof(script_path) != TYPE_STRING:
-			continue
-		
+	var script_path = options["post_script"]
+	if typeof(script_path) == TYPE_STRING and script_path != "":
 		script_path = script_path.strip_edges()
 		
 		var script = load(script_path)
@@ -148,7 +147,6 @@ func import(src, target_path, import_options, r_platform_variants, r_gen_files):
 		return FAILED
 
 	err = ResourceSaver.save(target_path, packed_scene)
-	print(target_path)
 	if err != OK:
 		print("Error saving scene")
 		return FAILED

--- a/addons/vnen.tiled_importer/tiled_map.gd
+++ b/addons/vnen.tiled_importer/tiled_map.gd
@@ -282,7 +282,7 @@ func build():
 		var tileset_path = options.tileset_directory + basename + ".res"
 		var err = ResourceSaver.save(tileset_path, single_tileset, ResourceSaver.FLAG_CHANGE_PATH)
 		if err != OK:
-			return "Couldn't save TileSet"
+			return "Couldn't save bundled TileSet for %s.tmx" % [basename]
 		single_tileset.take_over_path(tileset_path)
 
 	if options.bundle_tilesets:
@@ -460,7 +460,7 @@ func build():
 						var rot = 0
 						if obj.has("rotation"):
 							rot = float(obj.rotation)
-						occluder.set_rotation_in_degrees(-rot)
+						occluder.set_rotation_degrees(-rot)
 
 						var obj_visible = true
 						if obj.has("visible"):
@@ -476,7 +476,7 @@ func build():
 							_set_meta(occluder, obj.properties, obj.propertytypes)
 
 					else:
-						var body = StaticBody2D.new()
+						var body = Area2D.new()
 						if obj.has("name") and not obj.name.empty():
 							body.set_name(obj.name);
 						else:
@@ -524,7 +524,7 @@ func build():
 								rot = rot_offset - rot
 							else:
 								rot = -rot
-						body.set_rotation_in_degrees(rot)
+						body.set_rotation_degrees(rot)
 
 						var shape_owner = body.create_shape_owner(body)
 						body.shape_owner_add_shape(shape_owner, shape)
@@ -586,7 +586,7 @@ func build():
 					var rot = 0
 					if obj.has("rotation"):
 						rot = float(obj.rotation)
-					sprite.set_rotation_in_degrees(-rot)
+					sprite.set_rotation_degrees(-rot)
 
 					var obj_visible = true
 					if obj.has("visible"):

--- a/addons/vnen.tiled_importer/tiled_map.gd
+++ b/addons/vnen.tiled_importer/tiled_map.gd
@@ -137,7 +137,6 @@ func build():
 		var margin = 0
 		var firstgid = 0
 		var image = ImageTexture.new()
-		var target_dir = ""
 		var image_path = ""
 		var image_h = 0
 		var image_w = 0
@@ -172,13 +171,6 @@ func build():
 			image = load(image_path)
 			if typeof(image) == TYPE_STRING:
 				return image
-		else:
-			if options.separate_img_dir:
-				target_dir = options.target.get_base_dir().plus_file(options.tileset_directory).plus_file(name)
-				if not Directory.new().dir_exists(target_dir):
-					Directory.new().make_dir_recursive(target_dir)
-			else:
-				target_dir = options.target.get_base_dir().plus_file(options.tileset_directory)
 
 		var gid = firstgid
 		
@@ -287,7 +279,7 @@ func build():
 	if options.bundle_tilesets and options.save_tilesets:
 		single_tileset.set_name(basename)
 
-		var tileset_path = options.target.get_base_dir().plus_file(options.tileset_directory + basename + ".res")
+		var tileset_path = options.tileset_directory + basename + ".res"
 		var err = ResourceSaver.save(tileset_path, single_tileset, ResourceSaver.FLAG_CHANGE_PATH)
 		if err != OK:
 			return "Couldn't save TileSet"

--- a/addons/vnen.tiled_importer/tiled_map.gd
+++ b/addons/vnen.tiled_importer/tiled_map.gd
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2017 George Marques
+# Copyright (c) 2016 George Marques
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -54,8 +54,7 @@ func get_data():
 		var tiled_raw_data = f.get_as_text()
 		f.close()
 
-		data = parse_json(tiled_raw_data)
-		if typeof(data) != TYPE_DICTIONARY:
+		if data.parse_json(tiled_raw_data) != OK:
 			return "Couldn't parse the source file"
 	else:
 		data = _tmx_to_dict(source)
@@ -87,7 +86,7 @@ func build():
 
 	var single_tileset = null
 
-	if options.single_tileset:
+	if options.bundle_tilesets:
 		single_tileset = TileSet.new()
 
 	# Make tilesets
@@ -96,14 +95,15 @@ func build():
 		if tstemp.has("source"):
 			var err = OK
 			var tileset_src = source.get_base_dir().plus_file(tstemp.source) if tstemp.source.is_rel_path() else tstemp.source
-			if tileset_src.get_extension() == "json":
+			if tileset_src.extension() == "json":
 				var f = File.new()
 				err = f.open(tileset_src, File.READ)
 				if err != OK:
 					return "Couldn't open tileset file %s." % [tileset_src]
 
-				ts = parse_json(f.get_as_text())
-				if typeof(ts) != TYPE_DICTIONARY:
+				ts = {}
+				err = ts.parse_json(f.get_as_text())
+				if err != OK:
 					return "Couldn't parse tileset file %s." % [tileset_src]
 			else:
 				var tsparser = XMLParser.new()
@@ -121,10 +121,14 @@ func build():
 					return "Error parsing tileset file %s." % [tileset_src]
 
 				ts = _parse_tileset(tsparser)
+			ts.source_dir = tileset_src.get_base_dir()
 			ts.firstgid = int(tstemp.firstgid)
 
+		if not ts.has("source_dir"):
+			ts.source_dir = options.basedir
+
 		var tileset = null
-		if options.single_tileset:
+		if options.bundle_tilesets:
 			tileset = single_tileset
 		else:
 			tileset = TileSet.new()
@@ -164,20 +168,21 @@ func build():
 			return "Missing tile count (%s)" % [name]
 		if ts.has("image"):
 			has_global_img = true
-			image_path = options.basedir.plus_file(ts.image) if ts.image.is_rel_path() else ts.image
-			target_dir = options.target.get_base_dir().plus_file(options.rel_path)
-			image = _load_image(image_path, target_dir, name + ".png", image_w, image_h)
+			image_path = ts.source_dir.plus_file(ts.image) if ts.image.is_rel_path() else ts.image
+			image = load(image_path)
 			if typeof(image) == TYPE_STRING:
 				return image
 		else:
 			if options.separate_img_dir:
-				target_dir = options.target.get_base_dir().plus_file(options.rel_path).plus_file(name)
+				target_dir = options.target.get_base_dir().plus_file(options.tileset_directory).plus_file(name)
 				if not Directory.new().dir_exists(target_dir):
 					Directory.new().make_dir_recursive(target_dir)
 			else:
-				target_dir = options.target.get_base_dir().plus_file(options.rel_path)
+				target_dir = options.target.get_base_dir().plus_file(options.tileset_directory)
 
 		var gid = firstgid
+		
+		var tile_meta = {}
 
 		var x = margin
 		var y = margin
@@ -188,22 +193,21 @@ func build():
 			var tilepos = Vector2(x,y)
 			var region = Rect2(tilepos, tilesize)
 
+			var rel_id = str(gid - firstgid)
+
 			tileset.create_tile(gid)
 			if has_global_img:
 				tileset.tile_set_texture(gid, image)
 				tileset.tile_set_region(gid, region)
-
-			var rel_id = str(gid - firstgid)
-
-			if not rel_id in ts.tiles:
+			elif not rel_id in ts.tiles:
 				gid += 1
 				continue
 
 			if not has_global_img and "image" in ts.tiles[rel_id]:
 				var _img = ts.tiles[rel_id].image
-				image_path = options.basedir.plus_file(_img) if _img.is_rel_path() else _img
-				_img = _img.get_file().get_basename()
-				image = _load_image(image_path, target_dir, "%s_%s_%s.png" % [name, _img, rel_id], cell_size.x, cell_size.y)
+				image_path = ts.source_dir.plus_file(_img) if _img.is_rel_path() else _img
+				_img = _img.get_file().basename()
+				image = load(image_path)
 				if typeof(image) == TYPE_STRING:
 					return image
 				tileset.tile_set_texture(gid, image)
@@ -226,8 +230,28 @@ func build():
 						tileset.tile_set_light_occluder(gid, shape)
 						tileset.tile_set_occluder_offset(gid, offset)
 					else:
-						tileset.tile_set_shape(gid, shape)
-						tileset.tile_set_shape_offset(gid, offset)
+						var shape_id = tileset.tile_get_shape_count(gid)
+						tileset.tile_set_shape(gid, shape_id, shape)
+						tileset.tile_set_shape_transform(gid, shape_id, Transform2D(0, offset))
+
+			if options.custom_properties and "tiles" in ts and rel_id in ts.tiles and "properties" in ts.tiles[rel_id] and "propertytypes" in ts.tiles[rel_id]:
+				# If the tile has properties, create a dict with them and then save that new dict to the tile_meta dict using its gid
+				var tile_props = ts.tiles[rel_id].properties
+				var tile_prop_types = ts.tiles[rel_id].propertytypes
+				var tile_prop_dict = {}
+				for tile_prop_name in tile_props:
+					if tile_prop_types[tile_prop_name].to_lower() == "bool":
+						tile_prop_dict[tile_prop_name] = bool(tile_props[tile_prop_name])
+					elif tile_prop_types[tile_prop_name].to_lower() == "color":
+						tile_prop_dict[tile_prop_name] = Color(tile_props[tile_prop_name])
+					elif tile_prop_types[tile_prop_name].to_lower() == "float":
+						tile_prop_dict[tile_prop_name] = float(tile_props[tile_prop_name])
+					elif tile_prop_types[tile_prop_name].to_lower() == "int":
+						tile_prop_dict[tile_prop_name] = int(tile_props[tile_prop_name])
+					else:
+						tile_prop_dict[tile_prop_name] = str(tile_props[tile_prop_name])
+				
+				tile_meta[gid] = tile_prop_dict
 
 			gid += 1
 			i += 1
@@ -236,14 +260,17 @@ func build():
 				x = margin
 				y += int(tilesize.y) + spacing
 
-		if options.custom_properties and ts.has("properties") and ts.has("propertytypes"):
-			_set_meta(tileset, ts.properties, ts.propertytypes)
+		if options.custom_properties:
+			if ts.has("properties") and ts.has("propertytypes"):
+				_set_meta(tileset, ts.properties, ts.propertytypes)
+			if tile_meta.size():
+				tileset.set_meta("tile_meta", tile_meta)
 
 		tileset.set_name(name)
 
-		if not options.single_tileset:
-			if not options.embed:
-				var tileset_path = options.target.get_base_dir().plus_file(options.rel_path + name + ".res")
+		if not options.bundle_tilesets:
+			if options.save_tilesets:
+				var tileset_path = options.tileset_directory + name + ".res"
 				var err = ResourceSaver.save(tileset_path, tileset, ResourceSaver.FLAG_CHANGE_PATH)
 				if err != OK:
 					return "Couldn't save TileSet %s" % [name]
@@ -257,25 +284,26 @@ func build():
 				"tileset": tileset,
 			}
 
-	if options.single_tileset and not options.embed:
+	if options.bundle_tilesets and options.save_tilesets:
 		single_tileset.set_name(basename)
 
-		var tileset_path = options.target.get_base_dir().plus_file(options.rel_path + basename + ".res")
+		var tileset_path = options.target.get_base_dir().plus_file(options.tileset_directory + basename + ".res")
 		var err = ResourceSaver.save(tileset_path, single_tileset, ResourceSaver.FLAG_CHANGE_PATH)
 		if err != OK:
 			return "Couldn't save TileSet"
 		single_tileset.take_over_path(tileset_path)
 
-	if options.single_tileset:
+	if options.bundle_tilesets:
 		tilesets = [single_tileset]
 
 	# TileSets done, creating the target scene
 
 	scene = Node2D.new()
-	scene.set_name(basename.substr(0,4));
+	scene.set_name(basename)
 
-	for layer in data.layers:
-		var l = layer
+	for l in data.layers:
+		if l.has("compression"):
+			return 'Tiled compressed format is not supported. Change your Map properties to a format without compression.'
 
 		if not l.has("type"):
 			return 'Invalid Tiled data: missing "type" key on layer.'
@@ -301,27 +329,23 @@ func build():
 			if "encoding" in l:
 				if l.encoding != "base64":
 					return 'Unsupported layer data encoding. Use Base64 or no enconding.'
-				else:
-					if l.has("compression"):
-						var layer_size = int(l.width) * int(l.height) * 4
-						layer_data = _parse_encoded_layer(l.data, l.compression, layer_size)
-					else:
-						layer_data = _parse_encoded_layer(l.data)
-					if typeof(layer_data) == TYPE_STRING:
-						return layer_data
+				layer_data = _parse_base64_layer(l.data)
 
 			var tilemap = TileMap.new()
+			var ts_modulate = tilemap.get_modulate()
+			ts_modulate.a = opacity
+
 			tilemap.set_name(name)
-			tilemap.cell_size = cell_size
-			tilemap.modulate = Color(1, 1, 1, opacity)
-			tilemap.visible = visible
-			tilemap.mode = map_mode
+			tilemap.set_cell_size(cell_size)
+			tilemap.set_modulate(ts_modulate)
+			tilemap.set_visible(visible)
+			tilemap.set_mode(map_mode)
 
 			var offset = Vector2()
 			if l.has("offsetx") and l.has("offsety"):
 				offset = Vector2(int(l.offsetx), int(l.offsety))
 
-			tilemap.position = offset
+			tilemap.set_position(offset)
 
 			var firstgid = 0
 			tilemap.set_tileset(_tileset_from_gid(firstgid))
@@ -376,17 +400,19 @@ func build():
 				offset.y = float(l.offsety)
 
 			var image_path = options.basedir.plus_file(l.image) if l.image.is_rel_path() else l.image
-			var target_dir = options.target.get_base_dir().plus_file(options.rel_path)
-			var image = _load_image(image_path, target_dir, l.name + ".png")
+			var image = load(image_path)
 
 			if typeof(image) == TYPE_STRING:
 				return image
 
-			sprite.texture = image
-			sprite.modulate = Color(1, 1, 1, opacity)
-			sprite.visible = visible
+			var spr_modulate = sprite.get_modulate()
+			spr_modulate.a = opacity
+
+			sprite.set_texture(image)
+			sprite.set_modulate(spr_modulate)
+			sprite.set_visible(visible)
 			scene.add_child(sprite)
-			sprite.position = pos + offset
+			sprite.set_position(pos + offset)
 			sprite.set_owner(scene)
 
 		elif l.type == "objectgroup":
@@ -401,9 +427,12 @@ func build():
 			if options.custom_properties and l.has("properties") and l.has("propertytypes"):
 				_set_meta(object, l.properties, l.propertytypes)
 
+			var obj_modulate = object.get_modulate()
+			obj_modulate.a = opacity
+			
 			object.set_name(l.name)
-			object.set_opacity(opacity)
-			object.set_hidden(not visible)
+			object.set_modulate(obj_modulate)
+			object.set_visible(visible)
 			scene.add_child(object)
 			object.set_owner(scene)
 
@@ -428,17 +457,17 @@ func build():
 							pos.x = float(obj.x)
 						if obj.has("y"):
 							pos.y = float(obj.y)
-						occluder.set_pos(pos)
+						occluder.set_position(pos)
 
 						var rot = 0
 						if obj.has("rotation"):
 							rot = float(obj.rotation)
-						occluder.set_rotd(-rot)
+						occluder.set_rotation_in_degrees(-rot)
 
 						var obj_visible = true
 						if obj.has("visible"):
 							obj_visible = bool(obj.visible)
-						occluder.set_hidden(not obj_visible)
+						occluder.set_visible(obj_visible)
 
 						occluder.set_occluder_polygon(shape)
 
@@ -467,7 +496,7 @@ func build():
 								offset = Vector2(shape.get_radius(), shape.get_radius())
 							elif shape is CapsuleShape2D:
 								offset = Vector2(shape.get_radius(), shape.get_height())
-							collision.set_pos(-offset)
+							collision.set_position(-offset)
 							rot_offset = 180
 						else:
 							collision = CollisionPolygon2D.new()
@@ -488,7 +517,7 @@ func build():
 						var obj_visible = true
 						if obj.has("visible"):
 							obj_visible = bool(obj.visible)
-						body.set_hidden(not obj_visible)
+						body.set_visible(not obj_visible)
 
 						var rot = 0
 						if obj.has("rotation"):
@@ -497,9 +526,11 @@ func build():
 								rot = rot_offset - rot
 							else:
 								rot = -rot
-						body.set_rotd(rot)
+						body.set_rotation_in_degrees(rot)
 
-						body.add_shape(shape, Matrix32(0, -offset))
+						var shape_owner = body.create_shape_owner(body)
+						body.shape_owner_add_shape(shape_owner, shape)
+						body.shape_owner_set_transform(shape_owner, Transform2D(0, -offset))
 
 						body.add_child(collision)
 						object.add_child(body)
@@ -512,7 +543,7 @@ func build():
 						if obj.has("y"):
 							pos.y = float(obj.y)
 
-						body.set_pos(pos)
+						body.set_position(pos)
 
 						if options.custom_properties and obj.has("properties") and obj.has("propertytypes"):
 							_set_meta(body, obj.properties, obj.propertytypes)
@@ -524,10 +555,13 @@ func build():
 					if tileset == null:
 						return "Invalid GID in object layer tile"
 
+					var is_tile_object = tileset.tile_get_region(tileid) != Rect2(0, 0, 0, 0)
 					var sprite = Sprite.new()
 					sprite.set_texture(tileset.tile_get_texture(tileid))
-					sprite.set_region(true)
-					sprite.set_region_rect(tileset.tile_get_region(tileid))
+
+					if is_tile_object:
+						sprite.set_region(true)
+						sprite.set_region_rect(tileset.tile_get_region(tileid))
 
 					if obj.has("name") and not obj.name.empty():
 						sprite.set_name(obj.name);
@@ -544,23 +578,34 @@ func build():
 						pos.x = float(obj.x)
 					if obj.has("y"):
 						pos.y = float(obj.y)
-					sprite.set_pos(pos)
+					if is_tile_object:
+						# Tile object positions are oriented bottom left.
+						# If we import their positioning data as is, their position ends up skewed incorrectly.
+						pos.x = pos.x + float(obj.width) / 2
+						pos.y = pos.y - float(obj.height) / 2
+					sprite.set_position(pos)
 
 					var rot = 0
 					if obj.has("rotation"):
 						rot = float(obj.rotation)
-					sprite.set_rotd(-rot)
+					sprite.set_rotation_in_degrees(-rot)
 
 					var obj_visible = true
 					if obj.has("visible"):
 						obj_visible = bool(obj.visible)
-					sprite.set_hidden(not obj_visible)
+					sprite.set_visible(obj_visible)
 
 					object.add_child(sprite)
 					sprite.set_owner(scene)
 
-					if options.custom_properties and obj.has("properties") and obj.has("propertytypes"):
-						_set_meta(sprite, obj.properties, obj.propertytypes)
+					if options.custom_properties:
+						var tile = _tile_from_gid(tile_raw_id)
+
+						if tile != null and tile.has("properties") and tile.has("propertytypes"):
+							_set_meta(sprite, tile.properties, tile.propertytypes)
+
+						if obj.has("properties") and obj.has("propertytypes"):
+							_set_meta(sprite, obj.properties, obj.propertytypes)
 
 	if options.custom_properties and data.has("properties") and data.has("propertytypes"):
 		_set_meta(scene, data.properties, data.propertytypes)
@@ -575,7 +620,7 @@ func get_scene():
 
 # Get the tileset based on the global tile id
 func _tileset_from_gid(gid):
-	if options.single_tileset:
+	if options.bundle_tilesets:
 		return tilesets[0]
 
 	for map_id in tile_id_mapping:
@@ -585,12 +630,21 @@ func _tileset_from_gid(gid):
 
 	return null
 
+# Get a tile based on the global tile id
+func _tile_from_gid(gid):
+	for tileset in data.tilesets:
+		if gid >= tileset.firstgid and gid < (tileset.firstgid + tileset.tilecount):
+			var rel_id = str(gid - tileset.firstgid)
+			return tileset.tiles[rel_id]
+
+	return null
+
 # Get a shape based on the object data
 func _shape_from_object(obj):
 	var shape = "No shape created. That really shouldn't happen..."
 
 	if "polygon" in obj or "polyline" in obj:
-		var vertices = Vector2Array()
+		var vertices = PoolVector2Array()
 
 		if "polygon" in obj:
 			for point in obj.polygon:
@@ -697,7 +751,7 @@ func _sort_points_cw(vertices):
 	var sorter = PointSorter.new(centroid)
 	vertices.sort_custom(sorter, "is_less")
 
-	return Vector2Array(vertices)
+	return PoolVector2Array(vertices)
 
 class PointSorter:
 	var center
@@ -726,19 +780,10 @@ class PointSorter:
 
 		return d1 < d2
 
-func _parse_encoded_layer(data, compression = "", buffer_size = 0):
+func _parse_base64_layer(data):
 	var decoded = Marshalls.base64_to_raw(data)
+
 	var result = []
-
-	if compression != "":
-		var compression_mode
-		match compression:
-			"zlib": compression_mode = File.COMPRESSION_DEFLATE
-			_: return "Unsupported compression type: " + compression
-
-		decoded = decoded.decompress(buffer_size, compression_mode)
-		if decoded.size() == 0:
-			return "Error decompressing the data"
 
 	for i in range(0, decoded.size(), 4):
 
@@ -751,22 +796,22 @@ func _parse_encoded_layer(data, compression = "", buffer_size = 0):
 	return result
 
 # Load, copy and verify image
-func _load_image(source_img, target_folder, filename, width = false, height = false):
-	var dir = Directory.new()
-	if not dir.file_exists(source_img):
-		return 'Referenced image "%s" not found' % [source_img]
-	var image = ImageTexture.new()
-	image.load(source_img)
-	image.set_flags(options.image_flags)
-
-	if not options.embed:
-		var target_image = target_folder.plus_file(filename)
-		var err = ResourceSaver.save(target_image, image)
-		if err != OK:
-			return "Couldn't save tileset image %s" % [target_image]
-		image.take_over_path(target_image)
-
-	return image
+#func _load_image(source_img, target_folder, filename, width = false, height = false):
+#	var dir = Directory.new()
+#	if not dir.file_exists(source_img):
+#		return 'Referenced image "%s" not found' % [source_img]
+#	var image = ImageTexture.new()
+#	image.load(source_img)
+#
+#	if options.save_tilesets:
+#		var target_image = target_folder.plus_file(filename)
+#
+#		var err = ResourceSaver.save(target_image, image)
+#		if err != OK:
+#			return "Couldn't save tileset image %s" % [target_image]
+#		image.take_over_path(target_image)
+#
+#	return image
 
 # Parse the custom properties and set as meta of the objet
 func _set_meta(obj, properties, types):
@@ -832,11 +877,13 @@ func _tmx_to_dict(path):
 						if err != OK:
 							return "Couldn't open tileset file %s." % [tileset_src]
 
-						var ts = parse_json(f.get_as_text())
-						if typeof(ts) != TYPE_DICTIONARY:
+						var ts = {}
+						err = ts.parse_json(f.get_as_text())
+						if err != OK:
 							return "Couldn't parse tileset file %s." % [tileset_src]
 
 						ts.firstgid = int(tileset_data.firstgid)
+						ts.source_dir = tileset_src.get_base_dir()
 						data.tilesets.push_back(ts)
 
 					else:
@@ -856,6 +903,7 @@ func _tmx_to_dict(path):
 
 						var ts = _parse_tileset(tsparser)
 						ts.firstgid = int(tileset_data.firstgid)
+						ts.source_dir = tileset_src.get_base_dir()
 						data.tilesets.push_back(ts)
 
 			elif parser.get_node_name() == "layer":
@@ -962,6 +1010,10 @@ func _parse_tile_data(parser):
 					obj_group.objects = []
 				var obj = _parse_object(parser)
 				obj_group.objects.push_back(obj)
+			elif parser.get_node_name() == "properties":
+				var prop_data = _parse_properties(parser)
+				data["properties"] = prop_data.properties
+				data["propertytypes"] = prop_data.propertytypes
 
 		err = parser.read()
 
@@ -981,7 +1033,11 @@ func _parse_object(parser):
 					break
 
 			elif parser.get_node_type() == XMLParser.NODE_ELEMENT:
-				if parser.get_node_name() == "ellipse":
+				if parser.get_node_name() == "properties":
+					var prop_data = _parse_properties(parser)
+					data["properties"] = prop_data.properties
+					data["propertytypes"] = prop_data.propertytypes
+				elif parser.get_node_name() == "ellipse":
 					data.ellipse = true
 				elif parser.get_node_name() == "polygon" or parser.get_node_name() == "polyline":
 					var points = []

--- a/addons/vnen.tiled_importer/vnen.tiled_importer.gd
+++ b/addons/vnen.tiled_importer/vnen.tiled_importer.gd
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2017 George Marques
+# Copyright (c) 2016 George Marques
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -28,19 +28,20 @@ var import_plugin = null
 func get_name():
 	return "Tiled Map Importer"
 
-func _enter_tree():
-	get_resource_filesystem().connect("filesystem_changed", self, "update_resources")
-	import_plugin = preload("tiled_importer_plugin.gd").new()
-	import_plugin.config(self)
-	add_import_plugin(import_plugin)
+func _start():
+	if import_plugin == null:
+		import_plugin = preload("tiled_importer_plugin.gd").new()
+		add_import_plugin(import_plugin)
 
-func reload_scene(path):
-	reload_scene_from_path(path)
+func _stop():
+	if import_plugin != null:
+		remove_import_plugin(import_plugin)
+		import_plugin = null
+
+
+
+func _enter_tree():
+	_start()
 
 func _exit_tree():
-	remove_import_plugin(import_plugin)
-	import_plugin = null
-
-func update_resources():
-	get_resource_filesystem().disconnect("filesystem_changed", self, "update_resources")
-	get_resource_filesystem().scan()
+	_stop()

--- a/addons/vnen.tiled_importer/vnen.tiled_importer.gd
+++ b/addons/vnen.tiled_importer/vnen.tiled_importer.gd
@@ -31,7 +31,6 @@ func get_name():
 func _start():
 	if import_plugin == null:
 		import_plugin = preload("tiled_importer_plugin.gd").new()
-		import_plugin.config(self)
 		add_import_plugin(import_plugin)
 
 func _stop():
@@ -44,6 +43,3 @@ func _enter_tree():
 
 func _exit_tree():
 	_stop()
-
-func reload_scene(path):
-	reload_scene_from_path(path)

--- a/addons/vnen.tiled_importer/vnen.tiled_importer.gd
+++ b/addons/vnen.tiled_importer/vnen.tiled_importer.gd
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 #
-# Copyright (c) 2016 George Marques
+# Copyright (c) 2017 George Marques
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,11 +26,12 @@ extends EditorPlugin
 var import_plugin = null
 
 func get_name():
-	return "Tiled Map Importer"
+	return "Tiled Map"
 
 func _start():
 	if import_plugin == null:
 		import_plugin = preload("tiled_importer_plugin.gd").new()
+		import_plugin.config(self)
 		add_import_plugin(import_plugin)
 
 func _stop():
@@ -38,10 +39,17 @@ func _stop():
 		remove_import_plugin(import_plugin)
 		import_plugin = null
 
-
-
 func _enter_tree():
+	get_resource_filesystem().connect("filesystem_changed", self, "update_resources")
 	_start()
 
 func _exit_tree():
 	_stop()
+
+
+func reload_scene(path):
+	reload_scene_from_path(path)
+
+func update_resources():
+	get_resource_filesystem().disconnect("filesystem_changed", self, "update_resources")
+	get_resource_filesystem().scan()

--- a/addons/vnen.tiled_importer/vnen.tiled_importer.gd
+++ b/addons/vnen.tiled_importer/vnen.tiled_importer.gd
@@ -40,16 +40,10 @@ func _stop():
 		import_plugin = null
 
 func _enter_tree():
-	get_resource_filesystem().connect("filesystem_changed", self, "update_resources")
 	_start()
 
 func _exit_tree():
 	_stop()
 
-
 func reload_scene(path):
 	reload_scene_from_path(path)
-
-func update_resources():
-	get_resource_filesystem().disconnect("filesystem_changed", self, "update_resources")
-	get_resource_filesystem().scan()


### PR DESCRIPTION
As well as changing options to better integrate with the way it works.

Images are now left in-place as there is no reason to move them now that the .tmx, .tsx and tileset images will be placed inside the project folder by default, meaning the images will already be imported automatically and can have their flags edited through the image importer.

Extended post-script capabilities to handle multiple scripts.

Includes the `tile_meta` changes I opened a pull request for on master, because I've been finding it very useful.


I'm sorry for the very messy changelist, but I actually wrote all of this from scratch based on the current master branch, not realizing there already was a godot-3 branch, and then retroactively merged in changes made to the source there, meaning a lot of things have different names or are slightly shuffled around.