### PR TITLE
Exclude top level files from zip downloads

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,12 @@
 *.gd	eol=lf
 *.cfg	eol=lf
+
+# Exclude all top-level files and directories (except addons) from zip downloads.
+# This makes installing through the AssetLib easier, because no files and folders
+# need to be unchecked.
+
+/.gitattributes    export-ignore
+/.gitignore        export-ignore
+/ISSUE_TEMPLATE.md export-ignore
+/LICENSE           export-ignore
+/README.md         export-ignore


### PR DESCRIPTION
`export-ignore`ing files with the `.gitattributes` file excludes files and folders from GitHub's .zip downloads. Cloning using Git is not affected and works as before.
This makes it easier to install the addon, because there is no need to uncheck unwanted files and folders from within Godot.
I've recently made the same change to Gut: https://github.com/bitwes/Gut/pull/52

You can test this using the `Download ZIP` button of my fork: https://github.com/cmfcmf/godot-tiled-importer/tree/patch-1