### PR TITLE
Add support for parsing Point objects in XML maps (fixes #76)

### DIFF
--- a/addons/vnen.tiled_importer/tiled_xml_to_dict.gd
+++ b/addons/vnen.tiled_importer/tiled_xml_to_dict.gd
@@ -266,6 +266,9 @@ func parse_object(parser):
 					data["properties"] = prop_data.properties
 					data["propertytypes"] = prop_data.propertytypes
 
+				elif parser.get_node_name() == "point":
+					data.point = true
+
 				elif parser.get_node_name() == "ellipse":
 					data.ellipse = true
 


### PR DESCRIPTION
A small fix to #76 

Objects of type `Point` weren't correctly parsed which resulted in them being transformed into the default `StaticBody2D`.