### PR TITLE
Ability to specify collision layer for tilemaps.

### DIFF
--- a/addons/vnen.tiled_importer/tiled_import_plugin.gd
+++ b/addons/vnen.tiled_importer/tiled_import_plugin.gd
@@ -77,6 +77,11 @@ func get_import_options(preset):
 			"hint_string": "Mipmaps,Repeat,Filter,Anisotropic,sRGB,Mirrored Repeat"
 		},
 		{
+			"name": "collision_layer",
+			"default_value": 1,
+			"property_hint": PROPERTY_HINT_LAYERS_2D_PHYSICS
+		},
+		{
 			"name": "embed_internal_images",
 			"default_value": true if preset == PRESET_PIXEL_ART else false
 		},

--- a/addons/vnen.tiled_importer/tiled_map_reader.gd
+++ b/addons/vnen.tiled_importer/tiled_map_reader.gd
@@ -155,6 +155,7 @@ func make_layer(layer, parent, root, data):
 		tilemap.cell_clip_uv = options.uv_clip
 		tilemap.cell_y_sort = true
 		tilemap.cell_tile_origin = TileMap.TILE_ORIGIN_BOTTOM_LEFT
+		tilemap.collision_layer = options.collision_layer
 
 		var offset = Vector2()
 		if "offsetx" in layer:


### PR DESCRIPTION
It is often necessary to know if collisions are with moving obstacles or with the background/level. Therefore it is useful to be able to specify the collision layer for imported maps.