### PR TITLE
Fix for plugin load error in 3.1

### DIFF
--- a/addons/vnen.tiled_importer/tiled_map_reader.gd
+++ b/addons/vnen.tiled_importer/tiled_map_reader.gd
@@ -765,7 +765,7 @@ func build_tileset_for_scene(tilesets, source_path, options):
 			set_tiled_properties_as_meta(result, ts)
 		if options.custom_properties:
 			if "properties" in ts and "propertytypes" in ts:
-				set_custom_properties(result, ts.properties, ts.propertytypes)
+				set_custom_properties(result, ts)
 
 	if options.custom_properties and options.tile_metadata:
 		result.set_meta("tile_meta", tile_meta)
@@ -843,7 +843,7 @@ func read_file(path):
 
 	var content = JSON.parse(file.get_as_text())
 	if content.error != OK:
-		print_error("Error parsing JSON: ", content.error_string)
+		print_error("Error parsing JSON: " + content.error_string)
 		return content.error
 
 	return content.result
@@ -868,7 +868,7 @@ func read_tileset_file(path):
 
 	var content = JSON.parse(file.get_as_text())
 	if content.error != OK:
-		print_error("Error parsing JSON: ", content.error_string)
+		print_error("Error parsing JSON: " + content.error_string)
 		return content.error
 
 	return content.result


### PR DESCRIPTION
Tested with 3.1 #29f2571 and 3.0.6

- Updates set_custom_properties call to pass the tileset object correctly.
- change print_error calls for 3.1

Fix #93