### PR TITLE
Add link to Wiki in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ format and avoid this. If you need to use JSON format for Tiled files, consider 
 the non-Tiled JSON files in a folder alongside a `.gdignore` file so Godot won't try
 to import them.
 
+Find more useage information on the [Wiki](https://github.com/vnen/godot-tiled-importer/wiki).
+
 ## Caveats on Tiled maps
 
 * Godot TileSets only have one navigation and one occluder per tile, so the last found


### PR DESCRIPTION
I recently found this plugin and thought it was great! However, I struggled to identify how to access object meta data from GDscript. Eventually, while google searching I ended up on the Wiki and found all of the answers. I propose a small change to the README to point others, looking for similar information, towards the Wiki.

Cheers