### PR TITLE
Added a work around to fix the checkerboard import bug

### DIFF
--- a/addons/vnen.tiled_importer/tiled_map_reader.gd
+++ b/addons/vnen.tiled_importer/tiled_map_reader.gd
@@ -220,6 +220,7 @@ func make_layer(layer, parent, root, data):
 		tilemap.visible = visible
 		tilemap.mode = map_mode
 		tilemap.cell_half_offset = map_offset
+		tilemap.format = 1
 		tilemap.cell_clip_uv = options.uv_clip
 		tilemap.cell_y_sort = true
 		tilemap.cell_tile_origin = TileMap.TILE_ORIGIN_BOTTOM_LEFT


### PR DESCRIPTION
I implemented a fix suggested in godotengine/godot#23631. This will fix Tiled Importer from importing tiles in a checkerboard fashion.

Fix #103