### PR TITLE
Add support for custom root nodes

### DIFF
--- a/addons/vnen.tiled_importer/tiled_import_plugin.gd
+++ b/addons/vnen.tiled_importer/tiled_import_plugin.gd
@@ -97,6 +97,12 @@ func get_import_options(preset):
 			"default_value": true
 		},
 		{
+			"name": "custom_root_node",
+			"default_value": "",
+			"property_hint": PROPERTY_HINT_FILE,
+			"hint_string": "*.tscn;PackedScene"
+		},
+		{
 			"name": "post_import_script",
 			"default_value": "",
 			"property_hint": PROPERTY_HINT_FILE,

--- a/addons/vnen.tiled_importer/tiled_map_reader.gd
+++ b/addons/vnen.tiled_importer/tiled_map_reader.gd
@@ -134,7 +134,12 @@ func build(source_path, options):
 		# Error happened
 		return tileset
 
-	var root = Node2D.new()
+	var root
+	if not options.custom_root_node.empty():
+		root = load(options.custom_root_node).instance()
+	else:
+		root = Node2D.new()
+
 	root.set_name(source_path.get_file().get_basename())
 	if options.save_tiled_properties:
 		set_tiled_properties_as_meta(root, map)


### PR DESCRIPTION
I thought this would be a nice feature to have and an easy one to implement.

Instead of changing the root node through the `post_import` method (and looking through the source code to see what the new root node needs to copy from the old), we can provide an import option that allows the user to specify a Scene they would like to use as the root instead of Node2D.

In my game this has proven to be very helpful since I use root nodes to further edit its direct children.

This also allows non-programmers to circumvent the `post_import` method for what is supposed to be a simple task.

I like this pull request, however, it's taken me longer to write this description than it did to write the commit for it, so if it's not a welcomed change, I wouldn't be too hurt over it. I just thought this would be useful! :)