### PR TITLE
Remove deprecated load, add tileset import order

### DIFF
--- a/addons/vnen.tiled_importer/tiled_map_reader.gd
+++ b/addons/vnen.tiled_importer/tiled_map_reader.gd
@@ -814,8 +814,7 @@ func load_image(rel_path, source_path, options):
 
 	var image = null
 	if embed:
-		image = ImageTexture.new()
-		image.load(total_path)
+		image = load(total_path)
 	else:
 		image = ResourceLoader.load(total_path, "ImageTexture")
 

--- a/addons/vnen.tiled_importer/tiled_tileset_import_plugin.gd
+++ b/addons/vnen.tiled_importer/tiled_tileset_import_plugin.gd
@@ -42,6 +42,9 @@ func get_recognized_extensions():
 func get_save_extension():
 	return "res"
 
+func get_import_order():
+	return 100
+
 func get_resource_type():
 	return "TileSet"
 


### PR DESCRIPTION
Hello!

When re-importing all assets I get following warning in my console:
![load_normally](https://user-images.githubusercontent.com/42484461/84902911-b32b1f80-b0ad-11ea-95f3-2a7c0bc99e05.PNG)

This method is deprecated and should not be used anymore.
Loading the texture directly without instancing a new ImageTexture is the preferred way instead.

Unfortunately this leads to an error on re-import:
![error_loading](https://user-images.githubusercontent.com/42484461/84903753-c7235100-b0ae-11ea-8ef8-2734462229a0.PNG)

I also fixed this import error by increasing the import order of the 'tiled_tileset_import_plugin.gd' Editor Plugin to 100. (Maybe it should be higher?)

Everything works without error now... please tell me what you think.
