### PR TITLE
remove setting of cell_tile_origin of tilemap and the texture offset …

### DIFF
--- a/addons/vnen.tiled_importer/tiled_import_plugin.gd
+++ b/addons/vnen.tiled_importer/tiled_import_plugin.gd
@@ -110,8 +110,6 @@ func get_option_visibility(option, options):
 func import(source_file, save_path, options, r_platform_variants, r_gen_files):
 	var map_reader = TiledMapReader.new()
 
-	# Offset is only optional for importing TileSets
-	options.apply_offset = true
 	var scene = map_reader.build(source_file, options)
 
 	if typeof(scene) != TYPE_OBJECT:

--- a/addons/vnen.tiled_importer/tiled_map_reader.gd
+++ b/addons/vnen.tiled_importer/tiled_map_reader.gd
@@ -223,7 +223,6 @@ func make_layer(layer, parent, root, data):
 		tilemap.format = 1
 		tilemap.cell_clip_uv = options.uv_clip
 		tilemap.cell_y_sort = true
-		tilemap.cell_tile_origin = TileMap.TILE_ORIGIN_BOTTOM_LEFT
 		tilemap.collision_layer = options.collision_layer
 
 		var offset = Vector2()
@@ -701,8 +700,6 @@ func build_tileset_for_scene(tilesets, source_path, options):
 			if has_global_image:
 				result.tile_set_texture(gid, image)
 				result.tile_set_region(gid, region)
-				if options.apply_offset:
-					result.tile_set_texture_offset(gid, Vector2(0, -tilesize.y))
 			elif not rel_id in ts.tiles:
 				gid += 1
 				continue
@@ -713,8 +710,6 @@ func build_tileset_for_scene(tilesets, source_path, options):
 					# Error happened
 					return image
 				result.tile_set_texture(gid, image)
-				if options.apply_offset:
-					result.tile_set_texture_offset(gid, Vector2(0, -image.get_height()))
 
 			if "tiles" in ts and rel_id in ts.tiles and "objectgroup" in ts.tiles[rel_id] \
 					and "objects" in ts.tiles[rel_id].objectgroup:
@@ -727,8 +722,6 @@ func build_tileset_for_scene(tilesets, source_path, options):
 						return shape
 
 					var offset = Vector2(float(object.x), float(object.y))
-					if options.apply_offset:
-						offset += result.tile_get_texture_offset(gid)
 					if "width" in object and "height" in object:
 						offset += Vector2(float(object.width) / 2, float(object.height) / 2)
 

--- a/addons/vnen.tiled_importer/tiled_tileset_import_plugin.gd
+++ b/addons/vnen.tiled_importer/tiled_tileset_import_plugin.gd
@@ -78,10 +78,6 @@ func get_import_options(preset):
 			"default_value": false
 		},
 		{
-			"name": "apply_offset",
-			"default_value": false
-		},
-		{
 			"name": "post_import_script",
 			"default_value": "",
 			"property_hint": PROPERTY_HINT_FILE,


### PR DESCRIPTION
…for tiles to be compatible with 3.2

New Tile Origin behavior in Godot 3.2 was intentional (see response to https://github.com/godotengine/godot/issues/41826).  In this PR I've taken out the code that seems unecessary.  This change works in Godot 3.2 as well as 3.1/3.0.  If there is a use case for setting the offset like this, please advise.  It would also be beneficial if the test cases used in creating the plugin were made public so contributors could do more thorough testing.
