### PR TITLE
add zstd compression support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Then enable the plugin on the Project Settings.
 * Both `.tmx` (XML) and `.json` formats for maps.
 * Both `.tsx` (XML) and `.json` formats for tilesets.
 * Support for Base64 encoded map.
-* Support for layer compression, both `zlib` and `gzip` are supported.
+* Support for layer compression, `zlib`, `gzip`, and `zstd` are supported.
 * Object templates.
 * Orthogonal, isometric, staggered, and hexagonal maps.
 * Import visibility and opacity from layers.

--- a/addons/vnen.tiled_importer/tiled_map_reader.gd
+++ b/addons/vnen.tiled_importer/tiled_map_reader.gd
@@ -1055,13 +1055,19 @@ func is_convex(vertices):
 	return true
 
 # Decompress the data of the layer
-# Compression argument is a string, either "gzip" or "zlib"
+# Compression argument is a string, either "gzip", "zlib", or "zstd"
 func decompress_layer_data(layer_data, compression, map_size):
-	if compression != "gzip" and compression != "zlib":
-		print_error("Unrecognized compression format: %s" % [compression])
-		return ERR_INVALID_DATA
-
-	var compression_type = File.COMPRESSION_DEFLATE if compression == "zlib" else File.COMPRESSION_GZIP
+	var compression_type = -1
+	match compression:
+		"zlib":
+			compression_type = File.COMPRESSION_DEFLATE
+		"gzip":
+			compression_type = File.COMPRESSION_GZIP
+		"zstd":
+			compression_type = File.COMPRESSION_ZSTD
+		_:
+			print_error("Unrecognized compression format: %s" % [compression])
+			return ERR_INVALID_DATA
 	var expected_size = int(map_size.x) * int(map_size.y) * 4
 	var raw_data = Marshalls.base64_to_raw(layer_data).decompress(expected_size, compression_type)
 
@@ -1236,7 +1242,7 @@ func validate_layer(layer):
 				print_error("Invalid data layer property.")
 				return ERR_INVALID_DATA
 			if "compression" in layer:
-				if layer.compression != "gzip" and layer.compression != "zlib":
+				if layer.compression != "gzip" and layer.compression != "zlib" and layer.compression != "zstd":
 					print_error("Invalid compression type.")
 					return ERR_INVALID_DATA
 		"imagelayer":


### PR DESCRIPTION
Added zstd compression support. To show how useful zstd is I am using it on a map I have that has 141x32 tiles. These are the file sizes of that one map with different compressions:
CSV(uncompressed): 47.2kB
Base64(uncompressed): 121.2kB
Base64(gzip): 2.2kB
Base64(zlib): 2.1kB
Base64(zstd): 1.9kB

However one of the biggest factors isn't just the size of the file. zstd is known for being faster at decompressing data than gzip and zlib. Which means that import times in godot for the maps are so much faster, especially for really large maps. This saves a lot of development time each time you have to modify a big map or importing many maps at once.