### PR TITLE
add collision mask import property

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,13 @@ are embedded, otherwise they will use the flags from their own import settings.
 The collision layer for the maps and objects imported. If you need custom layers for
 each object, consider using a post-import script.
 
+### Collision Mask (Map only)
+
+**Default: `1`**
+
+The collision mask for the maps and objects imported. If you need custom masks for
+each object, consider using a post-import script.
+
 ### Embed Internal Images
 
 **Default: `Off`**

--- a/addons/vnen.tiled_importer/tiled_import_plugin.gd
+++ b/addons/vnen.tiled_importer/tiled_import_plugin.gd
@@ -85,6 +85,11 @@ func get_import_options(preset):
 			"property_hint": PROPERTY_HINT_LAYERS_2D_PHYSICS
 		},
 		{
+			"name": "collision_mask",
+			"default_value": 1,
+			"property_hint": PROPERTY_HINT_LAYERS_2D_PHYSICS
+		},
+		{
 			"name": "embed_internal_images",
 			"default_value": true if preset == PRESET_PIXEL_ART else false
 		},

--- a/addons/vnen.tiled_importer/tiled_map_reader.gd
+++ b/addons/vnen.tiled_importer/tiled_map_reader.gd
@@ -232,6 +232,7 @@ func make_layer(layer, parent, root, data):
 		tilemap.cell_clip_uv = options.uv_clip
 		tilemap.cell_y_sort = true
 		tilemap.collision_layer = options.collision_layer
+		tilemap.collision_mask = options.collision_mask
 		tilemap.z_index = z_index
 
 		var offset = Vector2()


### PR DESCRIPTION
Added collision mask property to tile map imports. Useful to set objects that all tiles should collide with in a global manner.