### PR TITLE
add y sort property

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,13 @@ used in the Godot TileMap).
 
 Enable the Clip Uv (Filter Clip on Sprites) to avoid image bleeding on tiles.
 
+### Y Sort (Map only)
+
+**Default: `On`**
+
+The map's tiles will be drawn in order of their Y coordinates. If this is not needed
+it can be turned off to get better performance and more FPS when being drawn.
+
 ### Image Flags
 
 **Default: `Mipmaps, Repeat, Filter`** (Note: this is set as `Texture.FLAGS_DEFAULT`)

--- a/addons/vnen.tiled_importer/tiled_import_plugin.gd
+++ b/addons/vnen.tiled_importer/tiled_import_plugin.gd
@@ -74,6 +74,10 @@ func get_import_options(preset):
 			"default_value": true
 		},
 		{
+			"name": "y_sort",
+			"default_value": true
+		},
+		{
 			"name": "image_flags",
 			"default_value": 0 if preset == PRESET_PIXEL_ART else Texture.FLAGS_DEFAULT,
 			"property_hint": PROPERTY_HINT_FLAGS,

--- a/addons/vnen.tiled_importer/tiled_map_reader.gd
+++ b/addons/vnen.tiled_importer/tiled_map_reader.gd
@@ -230,7 +230,7 @@ func make_layer(layer, parent, root, data):
 		tilemap.cell_half_offset = map_offset
 		tilemap.format = 1
 		tilemap.cell_clip_uv = options.uv_clip
-		tilemap.cell_y_sort = true
+		tilemap.cell_y_sort = options.y_sort
 		tilemap.collision_layer = options.collision_layer
 		tilemap.z_index = z_index
 


### PR DESCRIPTION
This allows Y sorting to be turned on or off as a property. This is important because large tile maps of the size 512x512 for example create 262,144 objects and reserve memory for them while running and then it has to sort them constantly by their Y coordinates as they are drawn each frame.

With a map size of 512x512 I was getting around 10 FPS. After turning off y sorting on that map which I didn't need Y sorting at all, I am now sitting at 60 FPS running smoothly.