### PR TITLE
added more custom property, fixed collisions and light occluders position, enabled one-way collision and added light occluder node for tile objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,10 @@ Then enable the plugin on the Project Settings.
 * Map background imported as a parallax background (so it's virtually infinite)
 * Support for post-import script.
 * Support for tile animations.
-* Custom materials for tilesets
-* Set Z index per layer (via the ``z_index`` custom property).
+* Custom materials for tilesets or Custom material per tile (via the ``custom_material`` custom property).
+* Set Z index per layer or per tile (via the ``z_index`` custom property).
+* Set Name per tile (via the ``name`` custom property).
+
 
 ## Usage (once the plugin is enabled)
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Then enable the plugin on the Project Settings.
 * Map background imported as a parallax background (so it's virtually infinite)
 * Support for post-import script.
 * Support for tile animations.
-* Custom materials for tilesets or Custom material per tile (via the ``custom_material`` custom property).
+* Custom materials for tilesets or Custom materials per tile (via the ``custom_material`` custom property).
 * Set Z index per layer or per tile (via the ``z_index`` custom property).
 * Set Name per tile (via the ``name`` custom property).
 


### PR DESCRIPTION
-added "custom_material" custom property for single tile in tileset,
-added "name" custom property for single tile in tileset,
-added "z_index" custom property for single tile in tileset,
-fixed occluder position of tileset to match the texture position,
-fixed collision position of tile object to match the texture position,
-set collision type to "one-way" to add one way collision to your staticbody (tile object)
-set collision type to "occluder" to make light occluder  node to your tile object