### PR TITLE
add compatibility with tiled 1.9

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,3 +20,4 @@ In chronological order based on the first contribution.
 - [Ross Hadden (rosshadden)](https://github.com/rosshadden)
 - [Tim van Oosterhout (Tubeliar)](https://github.com/Tubeliar)
 - [SirRamEsq](https://github.com/SirRamEsq)
+- [Christopher Cromer](https://github.com/cromerc)

--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ Then enable the plugin on the Project Settings.
 * Object templates.
 * Orthogonal, isometric, staggered, and hexagonal maps.
 * Import visibility and opacity from layers.
-* Import collision/occluder/navigation shapes (based on Tiled object type).
+* Import collision/occluder/navigation shapes (based on Tiled object class/type).
 * Support for one-way collision shapes.
 * Custom import options, such as whether to enable UV clip.
 * Support for image layers.
 * Support for object layers, which are imported as StaticBody2D, Area2D or LightOccluder2D
-  for shapes (depending on the `type` property) and as Sprite for tiles.
+  for shapes (depending on the `class` or `type` property) and as Sprite for tiles.
 * Support for group layers, which are imported as `Node2D`s.
 * Custom properties for maps, layers, tilesets, and objects are imported as
   metadata. Custom properties on tiles can be imported into the TileSet resource.
@@ -92,9 +92,9 @@ Find more useage information on the [Wiki](https://github.com/vnen/godot-tiled-i
   will be converted to a capsule shape, which may be imprecise. However, if the
   Tiled ellipse is a perfect circle, a CircleShape2D will be used instead.
 
-* Set the type of the object to `area`, `navigation` or `occluder` to use it as such.
+* Set the class/type of the object to `area`, `navigation` or `occluder` to use it as such.
 
-* Set the type of the object to `one-way` to mark it as a one-way shape in Godot
+* Set the class/type of the object to `one-way` to mark it as a one-way shape in Godot
 (both on tile and on object layers).
 
 * Objects in object layer cannot be set as `navigation`.

--- a/addons/vnen.tiled_importer/tiled_xml_to_dict.gd
+++ b/addons/vnen.tiled_importer/tiled_xml_to_dict.gd
@@ -544,7 +544,9 @@ static func parse_properties(parser):
 						return ERR_INVALID_DATA
 
 					data.properties[prop_data.name] = prop_data.value
-					if prop_data.has("type"):
+					if prop_data.has("class"):
+						data.propertytypes[prop_data.name] = prop_data.class
+					elif prop_data.has("type"):
 						data.propertytypes[prop_data.name] = prop_data.type
 					else:
 						data.propertytypes[prop_data.name] = "string"


### PR DESCRIPTION
This PR adds compatibility with tiled 1.9. A major breaking change is that they changed the type attribute to now be called class.

I left the old type attribute in for now so that it should work with both 1.8 and 1.9.

This fixes the issue #157.