### PR TITLE
Reference objects as NodePath rather than Tiled id

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -20,3 +20,4 @@ In chronological order based on the first contribution.
 - [Ross Hadden (rosshadden)](https://github.com/rosshadden)
 - [Tim van Oosterhout (Tubeliar)](https://github.com/Tubeliar)
 - [SirRamEsq](https://github.com/SirRamEsq)
+- [bitbrain](https://github.com/bitbrain)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Then enable the plugin on the Project Settings.
   for shapes (depending on the `type` property) and as Sprite for tiles.
 * Support for group layers, which are imported as `Node2D`s.
 * Custom properties for maps, layers, tilesets, and objects are imported as
-  metadata. Custom properties on tiles can be imported into the TileSet resource.
+  metadata. Custom properties on tiles can be imported into the TileSet resource. Referenced objects in Tiled will be represented as NodePath object in Godot.
 * Map background imported as a parallax background (so it's virtually infinite)
 * Support for post-import script.
 * Support for tile animations.

--- a/addons/vnen.tiled_importer/tiled_map_reader.gd
+++ b/addons/vnen.tiled_importer/tiled_map_reader.gd
@@ -385,6 +385,7 @@ func make_layer(layer, parent, root, data):
 				point.visible = bool(object.visible) if "visible" in object else true
 				object_layer.add_child(point)
 				point.set_owner(root)
+				_all_node_objects_by_tiled_id[str(object.id)] = point
 				if "name" in object and not str(object.name).empty():
 					point.set_name(str(object.name))
 				elif "id" in object and not str(object.id).empty():
@@ -503,6 +504,7 @@ func make_layer(layer, parent, root, data):
 					body.visible = bool(object.visible) if "visible" in object else true
 					body.position = pos
 					body.rotation_degrees = rot
+					_all_node_objects_by_tiled_id[str(object.id)] = body
 
 			else: # "gid" in object
 				var tile_raw_id = int(str(object.gid)) & 0xFFFFFFFF
@@ -582,6 +584,7 @@ func make_layer(layer, parent, root, data):
 				sprite.centered = false
 				sprite.region_filter_clip = options.uv_clip
 				sprite.offset = Vector2(0, -texture_size.y)
+				_all_node_objects_by_tiled_id[str(object.id)] = sprite
 
 				if not has_collisions:
 					object_layer.add_child(sprite)


### PR DESCRIPTION
**Compatible with Tiled Version: 1.9.0**

## Description

Within Tiled, objects can be referenced like so:

![tiled](https://user-images.githubusercontent.com/822035/179423575-508d2c80-24c5-41c1-bef8-dc4329accef6.JPG)

However, within Godot the meta field shows up as Tiled integer id. This pull request changes this behaviour to instead populate the node path of the referenced object for easier lookup.